### PR TITLE
W1 n31 d6

### DIFF
--- a/Sources/TMDB/Navigation/TMDBNavigationDestinations.swift
+++ b/Sources/TMDB/Navigation/TMDBNavigationDestinations.swift
@@ -45,8 +45,13 @@ public struct TMDBNavigationDestinations: ViewModifier {
                 container: container,
                 apiKey: container.resolve(String.self, name: "tmdbApiKey")!,
                 type: type
-            ) { tvShowId in
-                TMDBRoute.tvShowDetail(tvShowId)
+            ) { id, mediaType in
+                switch mediaType {
+                case .movie:
+                    TMDBRoute.movieDetail(MovieRouteModel(id: id))
+                case .tv:
+                    TMDBRoute.tvShowDetail(id)
+                }
             }
         }
     }

--- a/Sources/TMDB_Discover/presentation/Previews/TMDBDiscoverDemoView.swift
+++ b/Sources/TMDB_Discover/presentation/Previews/TMDBDiscoverDemoView.swift
@@ -15,7 +15,7 @@ public struct TMDBDiscoverDemoView: View {
                         container: Container(),
                         apiKey: debugTMDBAPIKey,
                         type: .airingToday,
-                        detailRouteBuilder: { _ in 1 })
+                        detailRouteBuilder: { _,_ in 1 })
                     .tag(0)
                     .tabItem {
                         Label("First View", systemImage: "house")

--- a/Sources/TMDB_Discover/presentation/pages/DiscoverListPage.swift
+++ b/Sources/TMDB_Discover/presentation/pages/DiscoverListPage.swift
@@ -8,13 +8,13 @@ public struct DiscoverListPage<Route: Hashable>: View {
     @StateObject var viewModel: TVFeedViewModel
     @State private var useUIKitView = false
     let type: TVShowFeedType
-    let detailRouteBuilder: (Int) -> Route
+    let detailRouteBuilder: (Int, DiscoverMediaType) -> Route
 
     public init(
         container: Container,
         apiKey: String,
         type: TVShowFeedType,
-        detailRouteBuilder: @escaping (Int) -> Route
+        detailRouteBuilder: @escaping (Int, DiscoverMediaType) -> Route
     ) {
         APIKeys.tmdbKey = apiKey
         let movieAssembly = DiscoverAssembly()

--- a/Sources/TMDB_Discover/presentation/widgets/TVShowListContent.swift
+++ b/Sources/TMDB_Discover/presentation/widgets/TVShowListContent.swift
@@ -4,11 +4,12 @@ import TMDB_Shared_UI
 @available(iOS 16.0, *)
 struct TVShowListContent<Route: Hashable>: View {
     let movies: [Movie]
-    let detailRouteBuilder: (Int) -> Route
+    let mediaType: DiscoverMediaType
+    let detailRouteBuilder: (Int, DiscoverMediaType) -> Route
 
     var body: some View {
         List(movies, id: \.id) { movie in
-            NavigationLink(value: detailRouteBuilder(movie.id), label: {
+            NavigationLink(value: detailRouteBuilder(movie.id, mediaType), label: {
                 MovieRow(movie: movie.toMovieRowEntity())
             })
         }.accessibilityIdentifier("TVShowListContent.List")
@@ -19,7 +20,18 @@ struct TVShowListContent<Route: Hashable>: View {
 struct TVShowListPageContent<Route: Hashable>: View {
     @StateObject var viewModel: TVFeedViewModel
     let type: TVShowFeedType
-    let detailRouteBuilder: (Int) -> Route
+    let detailRouteBuilder: (Int, DiscoverMediaType) -> Route
+
+    private var mediaType: DiscoverMediaType {
+        switch type {
+        case .discoverWithTVGenre:
+            return .tv
+        case .discoverWithGenre, .discoverWithCast, .discover:
+            return .movie
+        case .airingToday, .onTheAir:
+            return .tv
+        }
+    }
 
     var body: some View {
         Group {
@@ -30,7 +42,7 @@ struct TVShowListPageContent<Route: Hashable>: View {
                 Text(errorMessage)
                     .id("errorView")
             } else {
-                TVShowListContent(movies: viewModel.movies, detailRouteBuilder: detailRouteBuilder)
+                TVShowListContent(movies: viewModel.movies, mediaType: mediaType, detailRouteBuilder: detailRouteBuilder)
                     .id("movieListContent")
             }
         }
@@ -45,6 +57,6 @@ struct TVShowListPageContent<Route: Hashable>: View {
 #if DEBUG
 @available(iOS 16.0, *)
 #Preview {
-    TVShowListContent(movies: Movie.exampleMovies, detailRouteBuilder: { _ in 0 })
+    TVShowListContent(movies: Movie.exampleMovies, mediaType: .movie, detailRouteBuilder: { _, _ in 0 })
 }
 #endif

--- a/Sources/TMDB_Shared_Backend/TMDBEndpoint.swift
+++ b/Sources/TMDB_Shared_Backend/TMDBEndpoint.swift
@@ -97,6 +97,7 @@ public enum TMDBEndpoint {
     // Watch Providers
     case movieWatchProviders(watchRegion: String? = nil)
     case tvWatchProviders(watchRegion: String? = nil)
+    case tvShowWatchProviders(show: Int)
 
     // swiftlint:disable cyclomatic_complexity
     func path() -> String {
@@ -193,6 +194,8 @@ public enum TMDBEndpoint {
             return "watch/providers/movie"
         case .tvWatchProviders:
             return "watch/providers/tv"
+        case let .tvShowWatchProviders(show):
+            return "tv/\(show)/watch/providers"
         }
     }
 
@@ -491,6 +494,8 @@ public enum TMDBEndpoint {
             return TrendingAllResultModel.self
         case .movieWatchProviders, .tvWatchProviders:
             return WatchProviderListModel.self
+        case .watchProviders, .tvShowWatchProviders:
+            return WatchProviderResponse.self
         default:
             throw TMDBAPIError.unsupportedEndpoint
         }

--- a/Sources/TMDB_TVShowDetail/Views/TVShowDetailContentView.swift
+++ b/Sources/TMDB_TVShowDetail/Views/TVShowDetailContentView.swift
@@ -5,7 +5,7 @@ import TMDB_Shared_Backend
 @available(iOS 15, *)
 struct TVShowDetailContentView: View {
     @EnvironmentObject private var themeManager: ThemeManager
-
+    let apiService: TMDBAPIService
     let tvShow: TVShowDetailModel
 
     var body: some View {
@@ -13,6 +13,9 @@ struct TVShowDetailContentView: View {
             VStack(alignment: .leading, spacing: 20) {
                 TVShowHeaderView(tvShow: tvShow)
                 TVShowInfoView(tvShow: tvShow)
+
+                TVShowWatchProvidersSection(tvShowId: tvShow.id, apiService: apiService)
+
                 TVShowSeasonsView(tvShow: tvShow)
             }
             .padding()

--- a/Sources/TMDB_TVShowDetail/Views/TVShowDetailView.swift
+++ b/Sources/TMDB_TVShowDetail/Views/TVShowDetailView.swift
@@ -83,7 +83,7 @@ public struct TVShowDetailView: View {
         case .loading:
             LoadingStateView()
         case .loaded(let tvShow):
-            TVShowDetailContentView(tvShow: tvShow)
+            TVShowDetailContentView(apiService: apiService, tvShow: tvShow)
         case .error(let message):
             ErrorStateView(
                 message: message,

--- a/Sources/TMDB_TVShowDetail/Views/TVShowWatchProvidersSection.swift
+++ b/Sources/TMDB_TVShowDetail/Views/TVShowWatchProvidersSection.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import TMDB_Shared_Backend
+
+@available(iOS 15.0, *)
+struct TVShowWatchProvidersSection: View {
+    let tvShowId: Int
+    let apiService: TMDBAPIService
+
+    enum ViewState {
+        case loading
+        case success(WatchProviderResponse)
+        case error(String)
+    }
+
+    @State private var state: ViewState = .loading
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Where to Watch")
+                .font(.headline)
+                .padding(.horizontal)
+
+            contentView
+        }
+        .task(id: tvShowId) {
+            await loadProviders()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch state {
+        case .loading:
+            HStack {
+                ProgressView()
+                    .scaleEffect(0.8)
+                Text("Loading watch providers...")
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+
+        case .success(let response):
+            if let userRegion = Locale.current.regionCode,
+               let regionData = response.results[userRegion] {
+                WatchProvidersView(regionData: regionData)
+            } else if let firstRegion = response.results.first {
+                WatchProvidersView(regionData: firstRegion.value)
+            } else {
+                Text("No watch providers available")
+                    .foregroundColor(.secondary)
+                    .padding()
+            }
+
+        case .error(let message):
+            Text("Error: \(message)")
+                .foregroundColor(.red)
+                .padding()
+        }
+    }
+
+    private func loadProviders() async {
+        state = .loading
+        do {
+            let result: WatchProviderResponse = try await apiService.request(.tvShowWatchProviders(show: tvShowId))
+            state = .success(result)
+        } catch {
+            state = .error(error.localizedDescription)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct WatchProvidersView: View {
+    let regionData: WatchProviderRegion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Streaming services (flatrate)
+            if let flatrate = regionData.flatrate, !flatrate.isEmpty {
+                ProviderCategoryView(title: "Streaming", providers: flatrate, regionLink: regionData.link)
+            }
+
+            // Free services
+            if let free = regionData.free, !free.isEmpty {
+                ProviderCategoryView(title: "Free", providers: free, regionLink: regionData.link)
+            }
+
+            // Rent services
+            if let rent = regionData.rent, !rent.isEmpty {
+                ProviderCategoryView(title: "Rent", providers: rent, regionLink: regionData.link)
+            }
+
+            // Buy services
+            if let buy = regionData.buy, !buy.isEmpty {
+                ProviderCategoryView(title: "Buy", providers: buy, regionLink: regionData.link)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct ProviderCategoryView: View {
+    let title: String
+    let providers: [WatchProvider]
+    let regionLink: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(providers) { provider in
+                        ProviderLogoView(provider: provider, regionLink: regionLink)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct ProviderLogoView: View {
+    let provider: WatchProvider
+    let regionLink: String
+
+    var body: some View {
+        Button(action: {
+            if let url = URL(string: regionLink) {
+                UIApplication.shared.open(url)
+            }
+        }) {
+            AsyncImage(url: URL(string: provider.logoURL ?? "")) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } placeholder: {
+                Circle()
+                    .fill(Color.gray.opacity(0.3))
+                    .overlay(
+                        Text(provider.providerName.prefix(1))
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    )
+            }
+            .frame(width: 50, height: 50)
+            .clipShape(Circle())
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}


### PR DESCRIPTION
# Changelog

## [Unreleased] - Branch: w1_N31_D6

### Added
- **TV Show Watch Providers Section**
  - Added new `TVShowWatchProvidersSection` view component that displays where users can watch TV shows
  - Displays streaming services, free services, rent options, and buy options with provider logos
  - Automatically detects user's region and displays relevant providers
  - Includes loading and error states
  - Provider logos are clickable and open the watch provider link
  - Integrated into `TVShowDetailContentView` to show watch providers for each TV show

- **API Endpoint**
  - Added `tvShowWatchProviders(show: Int)` endpoint to `TMDBEndpoint` enum
  - Supports fetching watch provider information for specific TV shows

### Fixed
- **Navigation Bug Fix**
  - Fixed navigation routing to properly handle both movies and TV shows in discover lists
  - Updated `TMDBNavigationDestinations` to accept media type parameter and route to correct detail pages
  - Updated `DiscoverListPage` and `TVShowListContent` to pass media type information through navigation
  - Navigation now correctly routes to `movieDetail` for movies and `tvShowDetail` for TV shows based on the media type

### Changed
- Updated `detailRouteBuilder` closure signature from `(Int) -> Route` to `(Int, DiscoverMediaType) -> Route` to support media type-aware navigation
- Updated preview and demo views to match the new navigation signature

### Technical Details
- **Files Modified**: 8 files
- **Lines Added**: 192 insertions
- **Lines Removed**: 12 deletions
- **New Files**: 1 (`TVShowWatchProvidersSection.swift`)

### Commits
- `3f7ad69` - watch providers section
- `b9040ed` - fix navigation bug
